### PR TITLE
Implement broadcasts.get_top: types, validation, tests, and changelog

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,8 +5,9 @@ To be released
 --------------
 
 * Added ``pgn_in_json`` parameter to ``client.games.export``.
+* Implement `broadcasts.get_top()` endpoint; typing fixes and validation.
 
-Thanks to @hsheth2 for their contributions to this release.
+Thanks to @hsheth2 and @DoraFgr for their contributions to this release.
 
 v0.14.0 (2025-08-26)
 --------------------

--- a/berserk/types/broadcast.py
+++ b/berserk/types/broadcast.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any, Dict, List
+
 from typing_extensions import NotRequired, TypedDict
 
 from .common import Title
@@ -14,3 +16,14 @@ class BroadcastPlayer(TypedDict):
     rating: NotRequired[int]
     # Title, optional
     title: NotRequired[Title]
+
+
+class BroadcastTopResponse(TypedDict):
+    """Minimal TypedDict for /api/broadcast/top response."""
+
+    # List of active broadcasts
+    active: List[Dict[str, Any]]
+    # List of upcoming broadcasts
+    upcoming: List[Dict[str, Any]]
+    # List of past broadcasts
+    past: Dict[str, Any]

--- a/tests/clients/test_broadcasts.py
+++ b/tests/clients/test_broadcasts.py
@@ -1,0 +1,34 @@
+import pytest
+
+from berserk import Client
+
+
+def test_get_top_valid(monkeypatch, requests_mock):
+    client = Client()
+
+    sample = {
+        "active": [],
+        "upcoming": [],
+        "past": {"currentPage": 1, "maxPerPage": 24, "currentPageResults": []},
+    }
+
+    requests_mock.get(
+        "https://lichess.org/api/broadcast/top?page=1&html=False",
+        json=sample,
+    )
+
+    res = client.broadcasts.get_top(page=1, html=False)
+    assert isinstance(res, dict)
+    assert res["past"]["currentPage"] == 1
+
+
+def test_get_top_invalid_page_type():
+    client = Client()
+    with pytest.raises(ValueError):
+        client.broadcasts.get_top(page="one")  # type: ignore
+
+
+def test_get_top_invalid_page_value():
+    client = Client()
+    with pytest.raises(ValueError):
+        client.broadcasts.get_top(page=0)


### PR DESCRIPTION
Update changelog to acknowledge contributions from @DoraFgr

<!-- Describe your pull request here.-->


<details>
<summary>Checklist when adding a new endpoint</summary>


<!-- Once you create the PR, check off all the steps below that you have completed.
If any of these steps are not relevant or you have not completed, leave them unchecked.-->

- [x] Added new endpoint to the `README.md`
- [ ] Ensured that my endpoint name does not repeat the name of the client. Wrong: `client.users.get_user()`, Correct: `client.users.get()`
- [ ] Typed the returned JSON using TypedDicts in `berserk/types/`, [example](https://github.com/lichess-org/berserk/blob/master/berserk/types/team.py#L32)
- [ ] Written tests for GET endpoints not requiring authentification. [Documentation](https://github.com/lichess-org/berserk/blob/master/CONTRIBUTING.rst#using-pytest-recording--vcrpy), [example](https://github.com/lichess-org/berserk/blob/master/tests/clients/test_teams.py#L11)
- [ ] Added the endpoint and your name to `CHANGELOG.md` in the `To be released` section (to be created if necessary)
</details>
